### PR TITLE
bugfix buildnml for run duration

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -336,8 +336,8 @@ def buildnml(case, caseroot, compname):
 
     # get last day of previous run
     pday = ndastp % 100
-    pmonth = ndastp/100 % 100
-    pyear = ndastp / 100 / 100
+    pmonth = ndastp//100 % 100
+    pyear = ndastp // 100 // 100
     
     # Compute last day of the previous & current months
     lastday = 31


### PR DESCRIPTION
The definition of pmonth and pyear leads to not integer value, preventing the following condition to be satisfied. Hence, the length of the run duration was always fixed to the default value (31 days), regardless of the considered month.