### PR TITLE
Update Externals.cfg to tag nemo4.2.0_cm3_v04

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 
 [nemo]
 
-tag = nemo4.2.0_cm3_v02
+tag = nemo4.2.0_cm3_v04
 protocol = git
 repo_url = https://github.com/CMCC-Foundation/NEMO-CM.git
 local_path = source


### PR DESCRIPTION
Update the Externals.cfg to the nemo tag  nemo4.2.0_cm3_v04.
This version contains the update of:
- output required by SPS
- update of the ocean heat capacity constant