### PR TITLE
Add the py nemo rebuild in the Externals

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -7,6 +7,14 @@ repo_url = https://github.com/CMCC-Foundation/NEMO-CM.git
 local_path = source
 required = True
 
+[rebuild]
+
+tag = v0.4.0 
+protocol = git
+repo_url = https://github.com/CMCC-Foundation/py_nemo_rebuild.git
+local_path = source/utils/py_nemo_rebuild
+required = True
+
 [externals_description]
 schema_version = 1.0.0
 


### PR DESCRIPTION
Add the py_nemo_rebuild in Externals.cfg file in order to retrieve automatically the python rebuild for NEMO.